### PR TITLE
vendor-patches add additional autoload include path

### DIFF
--- a/packages/vendor-patches/bin/vendor-patches
+++ b/packages/vendor-patches/bin/vendor-patches
@@ -7,6 +7,7 @@ use Migrify\VendorPatches\HttpKernel\VendorPatchesKernel;
 $possibleAutoloadPaths = [
     __DIR__ . '/../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php',
     __DIR__ . '/../../../vendor/autoload.php',
 ];
 


### PR DESCRIPTION
Refer to #85. When installed with Composer, `vendor/bin/vendor-patches` is symlink from `vendor/migrify/vendor-patches/bin/vendor-patches`, so the correct path to the project's `autoload.php` is three levels up.